### PR TITLE
Change IComparer interface argument so that it accepts nulls.

### DIFF
--- a/Semver/Comparers/ISemVersionComparer.cs
+++ b/Semver/Comparers/ISemVersionComparer.cs
@@ -12,6 +12,6 @@ namespace Semver.Comparers;
 /// <see cref="SemVersion.SortOrderComparer"/> so that separate properties aren't needed for the
 /// <see cref="IEqualityComparer{T}"/> and <see cref="IComparer{T}"/> of <see cref="SemVersion"/>.
 /// </remarks>
-public interface ISemVersionComparer : IEqualityComparer<SemVersion>, IComparer<SemVersion>, IComparer
+public interface ISemVersionComparer : IEqualityComparer<SemVersion>, IComparer<SemVersion?>, IComparer
 {
 }

--- a/Semver/Comparers/PrecedenceComparer.cs
+++ b/Semver/Comparers/PrecedenceComparer.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Semver.Comparers;
 
-internal sealed class PrecedenceComparer : Comparer<SemVersion>, ISemVersionComparer
+internal sealed class PrecedenceComparer : Comparer<SemVersion?>, ISemVersionComparer
 {
     #region Singleton
     public static readonly ISemVersionComparer Instance = new PrecedenceComparer();

--- a/Semver/Comparers/SortOrderComparer.cs
+++ b/Semver/Comparers/SortOrderComparer.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Semver.Utility;
 
 namespace Semver.Comparers;
 
-internal sealed class SortOrderComparer : Comparer<SemVersion>, ISemVersionComparer
+internal sealed class SortOrderComparer : Comparer<SemVersion?>, ISemVersionComparer
 {
     #region Singleton
     public static readonly ISemVersionComparer Instance = new SortOrderComparer();

--- a/Semver/Comparers/UnbrokenSemVersionRangeComparer.cs
+++ b/Semver/Comparers/UnbrokenSemVersionRangeComparer.cs
@@ -13,7 +13,7 @@ namespace Semver.Comparers;
 /// the ranges they contain will be removed. Note that the <see cref="SemVersionRange"/> API
 /// will never expose this order exactly because contained ranges will not be included in the
 /// final <see cref="SemVersionRange"/>.</remarks>
-internal sealed class UnbrokenSemVersionRangeComparer : Comparer<UnbrokenSemVersionRange>
+internal sealed class UnbrokenSemVersionRangeComparer : Comparer<UnbrokenSemVersionRange?>
 {
     #region Singleton
     public static readonly UnbrokenSemVersionRangeComparer Instance = new();


### PR DESCRIPTION
Currently `ISemVersionComparer` and its concrete implementations implements `IComparer<SemVersion>` which forces one to use the bang operator when using it with some apis like the Linq Order APIs.

Current usage example:

```csharp
SemVersion?[] versions = [null, SemVersion.Parse(1, 0), null, SemVersion.Parse(2, 0)];

var ordered = versions
.OrderByDescending(x => x, SemVersion.PrecedenceComparer); // Shows CS8620: because x is SemVersion? but the comparer contract documents as SemVersion only.
```

To get rid of the warning, one has to use the !bang operator to make the compiler happy like so:

`.OrderByDescending(x => x, SemVersion.PrecedenceComparer!);`

However, I think this is unncessary as the implementation [rightly supports nullable comparison](https://github.com/WalkerCodeRanger/semver/blob/master/Semver/Comparers/PrecedenceComparer.cs#L14).

With this change, the nullability is also documented on the exposing interface to make usage in some APIS easier without any warnings.